### PR TITLE
Fix valgrind issues

### DIFF
--- a/src/utility.cpp
+++ b/src/utility.cpp
@@ -323,6 +323,7 @@ bool updateSystemJson(const ghc::filesystem::path& from, const ghc::filesystem::
     ifstream.close();
     ofstream.close();
 
+    delete[] buffer;
     return true;
 }
 

--- a/src/utility.cpp
+++ b/src/utility.cpp
@@ -523,4 +523,6 @@ std::string getPlatformFolder(RPGMakerVersion version, Platform platform) {
         GET_PLATFORM(Platform::Browser, "")
         GET_PLATFORM(Platform::Mobile, "")
     }
+
+    return "";
 }


### PR DESCRIPTION
Resolves #12 

```log
==6825== Memcheck, a memory error detector
==6825== Copyright (C) 2002-2017, and GNU GPL'd, by Julian Seward et al.
==6825== Using Valgrind-3.15.0-608cb11914-20190413 and LibVEX; rerun with -h for copyright info
==6825== Command: ./RPGMPacker
==6825== Parent PID: 4618
==6825== 
--6825-- 
--6825-- Valgrind options:
--6825--    --leak-check=full
--6825--    --show-leak-kinds=all
--6825--    --track-origins=yes
--6825--    --verbose
--6825--    --log-file=valgrind-out.txt
...
==6825== HEAP SUMMARY:
==6825==     in use at exit: 0 bytes in 0 blocks
==6825==   total heap usage: 33,768 allocs, 33,768 frees, 16,544,521 bytes allocated
==6825== 
==6825== All heap blocks were freed -- no leaks are possible
==6825== 
==6825== ERROR SUMMARY: 0 errors from 0 contexts (suppressed: 0 from 0)

```